### PR TITLE
Changed Adam's code to filter by content rating

### DIFF
--- a/avg_revenue_per_content_rating.sql
+++ b/avg_revenue_per_content_rating.sql
@@ -1,4 +1,4 @@
-SELECT g.primary_genre, ROUND(AVG(avg_ebt),2) AS av_ebt
+SELECT g.content_rating, ROUND(AVG(avg_ebt),2) AS av_ebt
 FROM (
 	  WITH cte1 AS (
 					SELECT DISTINCT s.name, 
@@ -81,6 +81,6 @@ FROM (
 	  ON a.name = cte2.name
 	  ORDER BY avg_ebt DESC
 	  ) AS g
-GROUP BY g.primary_genre
+GROUP BY g.content_rating
 ORDER BY av_ebt DESC;
 


### PR DESCRIPTION
I took Adam's code that he used to filter by primary genre and changed it to show the average revenue per content rating. The results are contrary to our top ten apps, showing us that Everyone +10 ratings have a higher average rating that Everyone.